### PR TITLE
Fix error output when program panics

### DIFF
--- a/src/command/client/search/mod.rs
+++ b/src/command/client/search/mod.rs
@@ -36,7 +36,7 @@ impl Cmd {
         if self.interactive {
             let command = interactive(self.query)?;
             if let Some(command) = command {
-                eprintln!("{}", command.command_text);
+                println!("{}", command.command_text);
             }
         } else {
             let commands = non_interactive(self.query)?;
@@ -59,7 +59,7 @@ fn interactive(query: Vec<String>) -> AppResult<Option<ShellCommand>> {
     let mut app: App<Database> = App::new(query.join(" "));
 
     // Initialize the terminal user interface.
-    let backend = CrosstermBackend::new(io::stdout());
+    let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
     let events = EventHandler::new(250);
     let mut tui = Tui::new(terminal, events);
@@ -79,7 +79,7 @@ fn interactive(query: Vec<String>) -> AppResult<Option<ShellCommand>> {
     }
 
     // Exit the user interface.
-    Tui::<CrosstermBackend<io::Stdout>>::reset()?;
+    Tui::<CrosstermBackend<io::Stderr>>::reset()?;
 
     // Return the selected command if the selection was confirmed
     // Vec::get handles out of bounds access if the Vec is empty

--- a/src/command/client/search/tui.rs
+++ b/src/command/client/search/tui.rs
@@ -36,7 +36,7 @@ impl<B: Backend> Tui<B> {
     /// It enables the raw mode and sets terminal properties.
     pub fn init(&mut self) -> AppResult<()> {
         terminal::enable_raw_mode()?;
-        crossterm::execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+        crossterm::execute!(io::stderr(), EnterAlternateScreen, EnableMouseCapture)?;
 
         // Define a custom panic hook to reset the terminal properties.
         // This way, you won't have your terminal messed up if an unexpected error happens.
@@ -66,8 +66,8 @@ impl<B: Backend> Tui<B> {
     /// the terminal properties if unexpected errors occur.
     pub fn reset() -> AppResult<()> {
         terminal::disable_raw_mode()?;
-        crossterm::execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
-        Terminal::new(CrosstermBackend::new(io::stdout()))?.show_cursor()?;
+        crossterm::execute!(io::stderr(), LeaveAlternateScreen, DisableMouseCapture)?;
+        Terminal::new(CrosstermBackend::new(io::stderr()))?.show_cursor()?;
         Ok(())
     }
 }

--- a/src/shell/chest.nu
+++ b/src/shell/chest.nu
@@ -2,9 +2,9 @@
 
 def _chest_search_cmd [...flags: string] {
   ([
-    `commandline (run-external --redirect-stderr chest search`,
+    `commandline (run-external --redirect-stdout chest search`,
     ($flags | append [--interactive, --] | each {|e| $'"($e)"'}),
-    `(commandline) | complete | $in.stderr | str substring ..-1)`,
+    `(commandline) | complete | $in.stdout | str substring ..-1)`,
   ] | flatten | str join ' ')
 }
 


### PR DESCRIPTION
Use Stdout for redirection so that messages on Stderr don't end up in the next prompt on panic.